### PR TITLE
feat: add controller-concurrent-workers option

### DIFF
--- a/cmd/rollout/app/options/options.go
+++ b/cmd/rollout/app/options/options.go
@@ -29,12 +29,13 @@ import (
 )
 
 type Options struct {
-	MetricsBindAddress     string
-	HealthProbeBindAddress string
-	LeaderElect            bool
-	FederatedMode          bool
-	Logger                 string
-	ZapOptions             *zap.Options
+	MetricsBindAddress          string
+	HealthProbeBindAddress      string
+	LeaderElect                 bool
+	FederatedMode               bool
+	Logger                      string
+	ZapOptions                  *zap.Options
+	ControllerConcurrentWorkers int
 }
 
 func NewOptions() *Options {
@@ -47,6 +48,7 @@ func NewOptions() *Options {
 		ZapOptions: &zap.Options{
 			Development: true,
 		},
+		ControllerConcurrentWorkers: 5,
 	}
 }
 
@@ -73,6 +75,7 @@ func (o *Options) Flags(initializer initializer.Interface) cliflag.NamedFlagSets
 			"Enabling this will ensure there is only one active controller manager.")
 	fs.BoolVar(&o.FederatedMode, "federated-mode", o.FederatedMode, "Enable federated mode for controller manager.")
 	fs.StringVar(&o.Logger, "logger", o.Logger, "The logger provider, Options are:\n"+strings.Join([]string{"zap", "klog"}, "\n"))
+	fs.IntVar(&o.ControllerConcurrentWorkers, "controller-concurrent-workers", o.ControllerConcurrentWorkers, "The number of concurrent workers for the controller.")
 
 	// bind zap flags
 	zapFs := flag.NewFlagSet("zap", flag.ExitOnError)

--- a/cmd/rollout/app/rollout.go
+++ b/cmd/rollout/app/rollout.go
@@ -106,7 +106,7 @@ func Run(opt *options.Options, initializer initializer.Interface) error {
 		options.NewCache = newMultiClusterCache
 
 		go func() {
-			if err := multiClusterManager.Run(1, ctx); err != nil {
+			if err := multiClusterManager.Run(opt.ControllerConcurrentWorkers, ctx); err != nil {
 				setupLog.Error(err, "unable to run multiClusterManager")
 				os.Exit(1)
 			}


### PR DESCRIPTION
<!-- Thank you for contributing to KusionStack!

Note: 

1. With pull requests:

    - Open your pull request against "main"
    - Your pull request should have no more than two commits, if not you should squash them.
    - It should pass all tests in the available continuous integration systems such as GitHub Actions.
    - You should add/modify tests to cover your proposed code changes.
    - If your pull request contains a new feature, please document it on the README.

2. Please create an issue first to describe the problem.

    We recommend that link the issue with the PR in the following question.
    For more info, check https://kusionstack.io/docs/governance/contribute/
-->

#### 1. Does this PR affect any open issues?(Y/N) and add issue references (e.g. "fix #123", "re #123".):

- [x] N
- [ ] Y 

<!-- You can add issue references here. 
    e.g. 
    fix #123, re #123, 
    fix https://github.com/XXX/issues/44
-->

#### 2. What is the scope of this PR (e.g. component or file name):

<!-- You can add the scope of this change here. 
    e.g. 
    /src/server/core.rs,
    kusionstack/KCLVM/kclvm-parser 
-->

#### 3. Provide a description of the PR(e.g. more details, effects, motivations or doc link):

<!-- You can choose a brief description here -->
- [ ] Affects user behaviors
- [ ] Contains syntax changes
- [ ] Contains variable changes
- [ ] Contains experimental features
- [ ] Performance regression: Consumes more CPU
- [ ] Performance regression: Consumes more Memory
- [x] Other
Add `multi-cluster-workers` option to set the number of threads for multi-cluster controller manager, accelerate the establishment of connections with the local cluster when starting rollout.

<!-- You can add more details here.
    e.g. 
    Call method "XXXX" to ..... in order to ....,
    More details: https://XXXX.com/doc......
-->

#### 4. Are there any breaking changes?(Y/N) and describe the breaking changes(e.g. more details, motivations or doc link):

- [x] N
- [ ] Y 

<!-- You can add more details here.
    e.g. 
    Calling method "XXXX" will cause the "XXXX", "XXXX" modules to be affected.
    More details: https://XXXX.com/doc......
-->

#### 5. Are there test cases for these changes?(Y/N) select and add more details, references or doc links:

<!-- You can choose a brief description here -->
- [ ] Unit test
- [ ] Integration test
- [ ] Benchmark (add benchmark stats below)
- [ ] Manual test (add detailed scripts or steps below)
- [ ] Other

<!-- You can add more details here.
e.g. 
The test case in XXXX is used to .....
test cases in /src/tests/XXXXX
test cases https://github.com/XXX/pull/44
benchmark stats: time XXX ms
-->

#### 6. Release note

<!-- compatibility change, improvement, bugfix, and new feature need a release note -->

Please refer to [Release Notes Language Style Guide](https://kusionstack.io/docs/governance/release-policy/) to write a quality release note.

```release-note
None
```
